### PR TITLE
Fix error conditional expression on isAdmin attribute in putUsers function

### DIFF
--- a/services/adminService.js
+++ b/services/adminService.js
@@ -124,7 +124,7 @@ const adminService = {
     return User.findByPk(req.params.id)
       .then((user) => {
         user.update({
-          isAdmin: req.body.isAdmin === 'true'
+          isAdmin: req.body.isAdmin === true
         })
           .then((restaurant) => {
             callback({


### PR DESCRIPTION
The **isAdmin** attribute of **user** should be kept as _boolean_ type.  So, instead of comparing it with _string_, it should be compared with another _boolean_ value.